### PR TITLE
No longer provide a feature in test-helper.el

### DIFF
--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -10,5 +10,4 @@
 	    (:exclude "*-test.el")
 	    (:report-file "/tmp/undercover-report.json"))
 
-(provide 'test-helper)
 ;;; test-helper.el ends here


### PR DESCRIPTION
The file isn't a library intended to be loaded with `require`.
Instead `ert-runner` loads it using `load`.  Other packages that
use `ert-runner` also come with a file named test-helper.el and
unfortunately many of those also provide `test-helper`, which
leads to conflicts.

Fixes #4.